### PR TITLE
Remove explicit Accept-Encoding header, which interferes with okhttps transparent gzip handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <version>${revision}</version>
     <packaging>hpi</packaging>
     <properties>
-        <revision>1.0.3</revision>
+        <revision>1.0.4</revision>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
         <jenkins.version>2.263.3</jenkins.version>
         <java.level>8</java.level>

--- a/src/main/java/io/jenkins/plugins/oak9/utils/Oak9ApiClient.java
+++ b/src/main/java/io/jenkins/plugins/oak9/utils/Oak9ApiClient.java
@@ -109,7 +109,6 @@ public class Oak9ApiClient {
                 .header("Authorization", credentials)
                 .header("Accept", "*/*")
                 .header("Cache-Control", "no-cache")
-                .header("Accept-Encoding", "gzip, deflate, br")
                 .url(this.baseUrl + "/" + this.orgId + "/validations/" + this.projectId + "/queue/iac?files")
                 .post(requestBody)
                 .build();


### PR DESCRIPTION
🐛 
Removed the explicit setting of the Accept-Encoding header to API requests, this allows okhttp3s transparent gzip handling to work properly. When the heading are explicitly set, okhttp3 does not automatically unzip the response.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
