### PR TITLE
Rethrow exceptions to improve handling when plugin is used in a pipeline 🚀 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <version>${revision}</version>
     <packaging>hpi</packaging>
     <properties>
-        <revision>1.0.4</revision>
+        <revision>1.0.5</revision>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
         <jenkins.version>2.263.3</jenkins.version>
         <java.level>8</java.level>


### PR DESCRIPTION
Previously the plugin would swallow exceptions when communicating with the oak9 API. This made it hard to catch plugin errors when the plugin is used in a pipeline.

With this update, API errors will be thrown by the plugin so they can be caught/logged/alerted at a higher level.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [N/A] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
