### PR TITLE
Update Jenkinsfile syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,13 +3,13 @@ def commonVersion = "2.263.3"
 def configurations = [
         [ platform: "linux", jdk: "8", jenkins: null ],
         // windows
-        [ platform: "windows", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],
+        [ platform: "windows", jdk: "8", jenkins: recentLTS ],
         // java 11
-        [ platform: "linux", jdk: "11", jenkins: recentLTS, javaLevel: "8" ],
+        [ platform: "linux", jdk: "11", jenkins: recentLTS ],
         // windows
-        [ platform: "windows", jdk: "8", jenkins: commonVersion, javaLevel: "8" ],
+        [ platform: "windows", jdk: "8", jenkins: commonVersion ],
         // java 11
-        [ platform: "linux", jdk: "11", jenkins: commonVersion, javaLevel: "8" ],
+        [ platform: "linux", jdk: "11", jenkins: commonVersion ],
 ]
 
 buildPlugin(configurations: configurations)


### PR DESCRIPTION
The javaLevel option is deprecated and does no longer set the Java version. The option is ignored.
This PR removes the unused option.

I'll expedite the merge, once the infrastructure changes on ci.jenkins.io are live, to prevent a failure on the master branch and new PRs.